### PR TITLE
Add new config keys: tools.view_image, disable_paste_burst, use_experimental_reasoning_summary

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,10 @@
 # New Keys Per Release
 
+- rust-main (2025-09-03)
+  - [tools].view_image — allow attaching local images to conversations.
+  - disable_paste_burst — disable multi-line paste burst submissions in TUI.
+  - use_experimental_reasoning_summary — enable experimental reasoning summaries in UI.
+
 - rust-v0.25.0 (2025-08-27)
   - No new config keys compared to v0.24.0. This release focused on TUI polish, bug fixes, and minor exec/stream behavior.
 
@@ -45,11 +50,14 @@ network_access = false             # allow outbound network from sandbox
 file_opener = "vscode"             # Opens files in VS Code
 show_raw_agent_reasoning = true    # Show raw reasoning content (if available)
 notify = ["notify-send", "Codex"]  # Desktop notifications
+use_experimental_reasoning_summary = false  # Experimental reasoning summaries
+disable_paste_burst = false                # Prevent rapid multi-line paste submissions
 
 # Tools
 [tools]
 web_search = true                  # Enable web search
 
+view_image = true                    # Attach local images as context
 # History
 [history]
 persistence = "save-all"           # Keep conversation history

--- a/codex-config-comprehensive.toml
+++ b/codex-config-comprehensive.toml
@@ -36,6 +36,17 @@
 #
 # 9) responses_originator_header_internal_override = "codex_cli_rs"   # Added Aug 19, 2025
 #    Internal/testing only; do not set unless you know why.
+#
+# 10) [tools].view_image = true   # Added Sep 3, 2025
+#     Enable the view_image tool so the agent can attach local images
+#     (paths on disk) to provide extra visual context.
+#
+# 11) disable_paste_burst = false   # Added Sep 3, 2025
+#     Disable multi-line paste burst sending in the TUI chat composer
+#     (helps avoid accidental rapid submissions of pasted content).
+#
+# 12) use_experimental_reasoning_summary = false   # Added Sep 3, 2025
+#     Opt-in UI toggle to render experimental reasoning summaries in the TUI.
 # ----------------------------------------------------------------------------
 
 ####################################
@@ -55,6 +66,10 @@ sandbox_mode = "danger-full-access"                      # "read-only" | "worksp
 # hide_agent_reasoning = false
 show_raw_agent_reasoning = true
 #
+# Disable multi-line paste burst submissions in TUI composer
+disable_paste_burst = false
+# Experimental: render reasoning summaries in TUI (if supported)
+use_experimental_reasoning_summary = false
 model_reasoning_effort = "high"               # "minimal" | "low" | "medium" | "high" | "none"
 # model_reasoning_summary = "auto"                # "auto" | "concise" | "detailed" | "none"
 # model_verbosity = "medium"                      # GPT‑5 family only; "low" | "medium" | "high"
@@ -82,6 +97,9 @@ model_reasoning_effort = "high"               # "minimal" | "low" | "medium" | "
 [tools]
 # Enable the native Responses web_search tool (same as TUI --search)
 web_search = true
+# Allow attaching local images to provide visual context
+
+view_image = true
 # alias for backwards compatibility:
 # web_search_request = true
 

--- a/codex-config-comprehensive.toml
+++ b/codex-config-comprehensive.toml
@@ -97,8 +97,6 @@ model_reasoning_effort = "high"               # "minimal" | "low" | "medium" | "
 [tools]
 # Enable the native Responses web_search tool (same as TUI --search)
 web_search = true
-# Allow attaching local images to provide visual context
-
 view_image = true
 # alias for backwards compatibility:
 # web_search_request = true

--- a/config.toml
+++ b/config.toml
@@ -104,6 +104,7 @@ include_only = [
 [tools]
 # Enable the native Responses web_search tool (same as `--search`).
 web_search = true
+view_image = true                              # Allow attaching local images
 # (alias supported for backwards-compat):
 #web_search_request = true
 
@@ -120,3 +121,5 @@ persistence = "save-all"          # Keeps conversation history across sessions
 [projects."/home/alif/Documents/GitHub/codex"]
 trust_level = "trusted"           # Skip security prompts for this repo
 
+use_experimental_reasoning_summary = false   # Experimental reasoning summaries in UI
+disable_paste_burst = false                  # Prevent rapid multi-line paste submissions


### PR DESCRIPTION
Updates to match upstream main (2025-09-03):

- Add [tools].view_image to allow attaching local images.
- Add disable_paste_burst (TUI composer safety toggle).
- Add use_experimental_reasoning_summary (opt‑in UI rendering).

Changes:
- codex-config-comprehensive.toml: document new keys; enable tools.view_image in [tools]; add top‑level toggles.
- config.toml: set defaults (view_image=true; disable_paste_burst=false; use_experimental_reasoning_summary=false).
- README.md: add “New Keys” section for 2025‑09‑03 and update example config blocks.

Notes:
- These keys are present in codex-rs core and TUI as of commit a56eb481 (Sep 3, 2025).